### PR TITLE
update EGIT_REPO_URI with new url for all ebuild

### DIFF
--- a/www-client/palemoon/palemoon-28.10.0.ebuild
+++ b/www-client/palemoon/palemoon-28.10.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://github.com/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/MCP/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-28.11.0.ebuild
+++ b/www-client/palemoon/palemoon-28.11.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://github.com/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/MCP/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-28.12.0.ebuild
+++ b/www-client/palemoon/palemoon-28.12.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://github.com/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/MCP/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-28.13.0-r1.ebuild
+++ b/www-client/palemoon/palemoon-28.13.0-r1.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://github.com/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/MCP/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-28.13.0.ebuild
+++ b/www-client/palemoon/palemoon-28.13.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://github.com/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/MCP/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-28.14.2.ebuild
+++ b/www-client/palemoon/palemoon-28.14.2.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://github.com/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/MCP/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="


### PR DESCRIPTION
The new url is now https://repo.palemoon.org/MCP/Pale-Moon.git