### PR TITLE
Pale Moon git repository moved to new location.

### DIFF
--- a/www-client/palemoon/palemoon-29.0.0.ebuild
+++ b/www-client/palemoon/palemoon-29.0.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.0.1.ebuild
+++ b/www-client/palemoon/palemoon-29.0.1.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.1.0.ebuild
+++ b/www-client/palemoon/palemoon-29.1.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.1.1.ebuild
+++ b/www-client/palemoon/palemoon-29.1.1.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.2.0.ebuild
+++ b/www-client/palemoon/palemoon-29.2.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.2.1.ebuild
+++ b/www-client/palemoon/palemoon-29.2.1.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.3.0.ebuild
+++ b/www-client/palemoon/palemoon-29.3.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.4.0.1.ebuild
+++ b/www-client/palemoon/palemoon-29.4.0.1.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.4.0.2.ebuild
+++ b/www-client/palemoon/palemoon-29.4.0.2.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="

--- a/www-client/palemoon/palemoon-29.4.0.ebuild
+++ b/www-client/palemoon/palemoon-29.4.0.ebuild
@@ -29,7 +29,7 @@ IUSE="
 	+devtools
 "
 
-EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
+EGIT_REPO_URI="https://repo.palemoon.org/mcp-graveyard/Pale-Moon.git"
 EGIT_COMMIT="${PV}_Release"
 
 DEPEND="


### PR DESCRIPTION
Pale Moon has restricted access to the development git repository, see forum post [Attention package builders! 29.4.1 and later](https://forum.palemoon.org/viewtopic.php?f=5&t=27369).

Unfortunely they failed to redirect the git repo used by the pre 29.4.1 palemoon ebuilds to the mcp-graveyard version (see forum post [No tag for release 29.4.1 in Pale-Moon.git](https://forum.palemoon.org/viewtopic.php?f=5&t=27365#p220122)) so this pull requests updates the old ebuilds to use the new location.