### PR TITLE
filter -ffast-math and add USE flags

### DIFF
--- a/www-client/palemoon/palemoon-32.3.1.ebuild
+++ b/www-client/palemoon/palemoon-32.3.1.ebuild
@@ -29,6 +29,10 @@ IUSE="
 	+devtools
 	+av1
 	+jpegxl
+	strip
+	eme
+	tests
+	gamepad
 "
 
 EGIT_REPO_URI="https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
@@ -88,7 +92,27 @@ src_configure() {
 	# Basic configuration:
 	mozconfig_init
 
-	mozconfig_disable updater install-strip accessibility gconf
+	mozconfig_disable updater accessibility gconf webrtc
+
+	if use strip; then
+		mozconfig_enable strip
+		mozconfig_enable install-strip
+	else
+                mozconfig_disable strip
+                mozconfig_disable install-strip
+	fi
+
+	if use eme; then
+		mozconfig_enable eme
+	else
+		mozconfig_disable eme
+	fi
+
+	if use gamepad; then
+		mozconfig_enable gamepad
+	else
+		mozconfig_disable gamepad
+	fi
 
 	if use official-branding; then
 		official-branding_warning
@@ -101,7 +125,8 @@ src_configure() {
 			O="${O} -msse2 -mfpmath=sse"
 		fi
 		mozconfig_enable "optimize=\"${O}\""
-		filter-flags '-O*' '-msse2' '-mfpmath=sse'
+		# -ffast-math causes runtime failures
+		filter-flags '-O*' '-msse2' '-mfpmath=sse' '-ffast-math'
 	else
 		mozconfig_disable optimize
 	fi
@@ -113,10 +138,14 @@ src_configure() {
 	if use debug; then
 		mozconfig_var MOZ_DEBUG_SYMBOLS 1
 		mozconfig_enable "debug-symbols=\"-gdwarf-2\""
+	else
+		mozconfig_disable debug
 	fi
 
 	if use jemalloc; then
 		mozconfig_enable jemalloc
+	else
+		mozconfig_disable jemalloc
 	fi
 
 	if use valgrind; then


### PR DESCRIPTION
Closes: https://github.com/deu/palemoon-overlay/issues/129

See:
https://developer.palemoon.org/build/linux/
https://forum.palemoon.org/viewtopic.php?f=5&t=30227
https://repo.palemoon.org/MoonchildProductions/Pale-Moon/issues/1934
https://repo.palemoon.org/MoonchildProductions/Pale-Moon/issues/1932

Adds USE flags to, among other things, make possible to create a .mozconfig simmilar to the default one and to not build things like drm and webrtc, the latter doesn't work with palemoon in any configuration.

Also added filtering for the -ffast-math CFLAG, because it results in runtime failures.

There is currently a build issue with binutils 2.41.
The way to fix that is to add this commit as a patch:
https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb

I didn't do that here because it's easy enough to do that locally and it will likely be fixed upstream soon enough. You can add it if you want:
```
--- a/platform/media/ffvpx/libavcodec/x86/mathops.h
+++ b/platform/media/ffvpx/libavcodec/x86/mathops.h
@@ -35,12 +35,20 @@
 static av_always_inline av_const int MULL(int a, int b, unsigned shift)
 {
     int rt, dummy;
+    if (__builtin_constant_p(shift))
     __asm__ (
         "imull %3               \n\t"
         "shrdl %4, %%edx, %%eax \n\t"
         :"=a"(rt), "=d"(dummy)
-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
+        :"a"(a), "rm"(b), "i"(shift & 0x1F)
     );
+    else
+        __asm__ (
+            "imull %3               \n\t"
+            "shrdl %4, %%edx, %%eax \n\t"
+            :"=a"(rt), "=d"(dummy)
+            :"a"(a), "rm"(b), "c"((uint8_t)shift)
+        );
     return rt;
 }

@@ -113,19 +121,31 @@ __asm__ volatile(\
 // avoid +32 for shift optimization (gcc should do that ...)
 #define NEG_SSR32 NEG_SSR32
 static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
+    if (__builtin_constant_p(s))
     __asm__ ("sarl %1, %0\n\t"
          : "+r" (a)
-         : "ic" ((uint8_t)(-s))
+         : "i" (-s & 0x1F)
     );
+    else
+        __asm__ ("sarl %1, %0\n\t"
+               : "+r" (a)
+               : "c" ((uint8_t)(-s))
+        );
     return a;
 }

 #define NEG_USR32 NEG_USR32
 static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
+    if (__builtin_constant_p(s))
     __asm__ ("shrl %1, %0\n\t"
          : "+r" (a)
-         : "ic" ((uint8_t)(-s))
+         : "i" (-s & 0x1F)
     );
+    else
+        __asm__ ("shrl %1, %0\n\t"
+               : "+r" (a)
+               : "c" ((uint8_t)(-s))
+        );
     return a;
 }
```

There is also the following patch which from my shallow testing may or may not slightly decrease build time. I didn't include it.
```
--- a/platform/python/mozbuild/mozbuild/test/configure/test_moz_configure.py    2023-08-29 21:25:40.505674044 +0300
+++ b/platform/python/mozbuild/mozbuild/test/configure/test_moz_configure.py    2023-08-29 21:27:34.903987259 +0300
@@ -31,13 +31,6 @@
                           get_value_for(['--enable-application=browser',
                                          'MOZ_PROFILING=1']))

-        value = get_value_for(
-            environ={'MOZ_PROFILING': '1'},
-            mozconfig='ac_add_options --enable-project=js')
-
-        self.assertEquals('--enable-project=js MOZ_PROFILING=1',
-                          value)
-
         # --disable-js-shell is the default, so it's filtered out.
         self.assertEquals('--enable-application=browser',
                           get_value_for(['--enable-application=browser',
--- a/platform/js/src/configure.in      2023-08-29 21:25:27.409200482 +0300
+++ b/platform/js/src/configure.in      2023-08-29 21:26:33.831554428 +0300
@@ -22,6 +22,6 @@
 TOPSRCDIR="$SRCDIR"/../..
 export OLD_CONFIGURE="$SRCDIR"/old-configure

-set -- "$@" --enable-project=js
+set -- "$@"

 which python2.7 > /dev/null && exec python2.7 "$TOPSRCDIR/configure.py" "$@" || exec python "$TOPSRCDIR/configure.py" "$@"
--- a/platform/build/subconfigure.py    2023-08-29 21:24:50.939738219 +0300
+++ b/platform/build/subconfigure.py    2023-08-29 21:26:11.801879253 +0300
@@ -317,7 +317,6 @@
             command = [
                 sys.executable,
                 os.path.join(os.path.dirname(__file__), '..', 'configure.py'),
-                '--enable-project=js',
             ]
             data['env']['OLD_CONFIGURE'] = os.path.join(
                 os.path.dirname(configure), 'old-configure')
```