### PR TITLE
Disable gold in mozconfig

### DIFF
--- a/www-client/palemoon/palemoon-33.1.0.ebuild
+++ b/www-client/palemoon/palemoon-33.1.0.ebuild
@@ -87,7 +87,7 @@ src_configure() {
 	# Basic configuration:
 	mozconfig_init
 
-	mozconfig_disable updater install-strip accessibility gconf
+	mozconfig_disable updater install-strip accessibility gconf gold
 
 	if use official-branding; then
 		official-branding_warning


### PR DESCRIPTION
After switching to profile `amd64/23.0` I've discovered that palemoon failed to rebuild. It turned out that Palemoon uses `ld.gold` for linking by default if it's found in the system (which is true in my case), and new `23.0` profile now has `-Wl,-z,pack-relative-relocs` in `LDFLAGS`, which is not supported by `ld.gold`. It seems to me that disabling gold would be the right thing to do, as it can only lead to slightly larger linking times which is not crucial here.